### PR TITLE
Add tests for Backup-Registry path selection

### DIFF
--- a/tests/Backup-Registry.Tests.ps1
+++ b/tests/Backup-Registry.Tests.ps1
@@ -1,0 +1,34 @@
+BeforeAll {
+    # Load the function under test
+    . (Join-Path $PSScriptRoot '../Lib-BackupRegistry.ps1')
+}
+
+Describe 'Backup-Registry' {
+    BeforeEach {
+        # Prevent filesystem and registry access
+        Mock -CommandName reg
+        Mock -CommandName New-Item
+    }
+
+    It 'returns a path under OneDrive when available' {
+        $env:OneDrive   = 'C:\Users\Test\OneDrive'
+        $env:USERPROFILE = 'C:\Users\Test'
+
+        Mock -CommandName Test-Path { $true }
+
+        $result = Backup-Registry -keys 'HKCU:\Software\Test' -label 'Test'
+
+        $result | Should -BeLike "$env:OneDrive\\RegistryBackups\\*"
+    }
+
+    It 'falls back to Documents when OneDrive is absent' {
+        Remove-Item Env:OneDrive -ErrorAction SilentlyContinue
+        $env:USERPROFILE = 'C:\Users\Test'
+
+        Mock -CommandName Test-Path { $false }
+
+        $result = Backup-Registry -keys 'HKCU:\Software\Test' -label 'Test'
+
+        $result | Should -BeLike "$env:USERPROFILE\\Documents\\RegistryBackups\\*"
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests ensuring Backup-Registry uses OneDrive path when available and falls back to Documents otherwise

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/Backup-Registry.Tests.ps1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce077de508327bcf9d1a8037a992b