### PR TITLE
Document NetworkThrottlingIndex setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Create a shortcut to Launch-TurboTweak.bat:
 
 ### Performance Tweaks
 - Sets StartupDelayInMSec=0, SystemResponsiveness=10.
+- Sets NetworkThrottlingIndex=0xffffffff for improved network performance.
 - Reboot; notice faster app starts and better foreground priority.
 
 ## Warnings and Risks


### PR DESCRIPTION
## Summary
- document that NetworkThrottlingIndex is set to 0xffffffff for improved network performance

## Testing
- `pwsh -NoLogo -NoProfile -Command "Get-ChildItem | Select-Object -First 5"` *(fails: command not found)*
- `apt-get update` *(fails: repository access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ce069967883279dd385a8949a822f