### PR TITLE
Ensure registry paths include drive colon

### DIFF
--- a/Add-Performance.ps1
+++ b/Add-Performance.ps1
@@ -16,8 +16,8 @@ $logPath = "$PSScriptRoot\TurboTweak.log"
 Add-Content -Path $logPath -Value "$(Get-Date): Starting Add-Performance"
 
 $keys = @(
-    "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Serialize",
-    "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile"
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Serialize",
+    "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile"
 )
 
 try {

--- a/Add-RegistryBackup.ps1
+++ b/Add-RegistryBackup.ps1
@@ -3,7 +3,7 @@
 
 . "$PSScriptRoot\Lib-BackupRegistry.ps1"
 
-$key = "HKLM\System\CurrentControlSet\Control\Session Manager\Configuration Manager"
+$key = "HKLM:\System\CurrentControlSet\Control\Session Manager\Configuration Manager"
 Backup-Registry @($key) "RegistryBackup"
 
 New-Item -Path $key -Force | Out-Null

--- a/Add-VerboseBoot.ps1
+++ b/Add-VerboseBoot.ps1
@@ -14,7 +14,7 @@ if ($confirm -ne 'y') { Write-Host "❌ Cancelled." -ForegroundColor Yellow; exi
 $logPath = "$PSScriptRoot\TurboTweak.log"
 Add-Content -Path $logPath -Value "$(Get-Date): Starting Add-VerboseBoot"
 
-$key = "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
+$key = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
 $keys = @($key)
 
 try {

--- a/Remove-Performance.ps1
+++ b/Remove-Performance.ps1
@@ -15,8 +15,8 @@ $logPath = "$PSScriptRoot\TurboTweak.log"
 Add-Content -Path $logPath -Value "$(Get-Date): Starting Remove-Performance"
 
 $keys = @(
-    "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Serialize",
-    "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile"
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Serialize",
+    "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile"
 )
 
 try {

--- a/Remove-RecentFolders.ps1
+++ b/Remove-RecentFolders.ps1
@@ -15,10 +15,10 @@ $logPath = "$PSScriptRoot\TurboTweak.log"
 Add-Content -Path $logPath -Value "$(Get-Date): Starting Remove-RecentFolders"
 
 $keys = @(
-    "HKCU\SOFTWARE\Classes\CLSID\{22877a6d-37a1-461a-91b0-dbda5aaebc99}",
-    "HKCU\SOFTWARE\Classes\CLSID\{22877a6d-37a1-461a-91b0-dbda5aaebc99}\ShellFolder",
-    "HKCU\SOFTWARE\Classes\Wow6432Node\CLSID\{22877a6d-37a1-461a-91b0-dbda5aaebc99}",
-    "HKCU\SOFTWARE\Classes\Wow6432Node\CLSID\{22877a6d-37a1-461a-91b0-dbda5aaebc99}\ShellFolder"
+    "HKCU:\SOFTWARE\Classes\CLSID\{22877a6d-37a1-461a-91b0-dbda5aaebc99}",
+    "HKCU:\SOFTWARE\Classes\CLSID\{22877a6d-37a1-461a-91b0-dbda5aaebc99}\ShellFolder",
+    "HKCU:\SOFTWARE\Classes\Wow6432Node\CLSID\{22877a6d-37a1-461a-91b0-dbda5aaebc99}",
+    "HKCU:\SOFTWARE\Classes\Wow6432Node\CLSID\{22877a6d-37a1-461a-91b0-dbda5aaebc99}\ShellFolder"
 )
 
 try {

--- a/Remove-RegistryBackup.ps1
+++ b/Remove-RegistryBackup.ps1
@@ -14,7 +14,7 @@ if ($confirm -ne 'y') { Write-Host "❌ Cancelled." -ForegroundColor Yellow; exi
 $logPath = "$PSScriptRoot\TurboTweak.log"
 Add-Content -Path $logPath -Value "$(Get-Date): Starting Remove-RegistryBackup"
 
-$key = "HKLM\System\CurrentControlSet\Control\Session Manager\Configuration Manager"
+$key = "HKLM:\System\CurrentControlSet\Control\Session Manager\Configuration Manager"
 $keys = @($key)
 
 try {

--- a/Remove-VerboseBoot.ps1
+++ b/Remove-VerboseBoot.ps1
@@ -14,7 +14,7 @@ if ($confirm -ne 'y') { Write-Host "❌ Cancelled." -ForegroundColor Yellow; exi
 $logPath = "$PSScriptRoot\TurboTweak.log"
 Add-Content -Path $logPath -Value "$(Get-Date): Starting Remove-VerboseBoot"
 
-$key = "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
+$key = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
 $keys = @($key)
 
 try {


### PR DESCRIPTION
## Summary
- add missing drive colon after registry hives in performance tweaks
- update verbose boot scripts to use HKLM:\ paths
- fix registry backup and recent folders scripts to use HKLM:\/HKCU:\ notation

## Testing
- `pwsh --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ce05a949c8327923f192a2d5c4e54