### PR TITLE
docs: clarify backup log instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Create a shortcut to Launch-TurboTweak.bat:
 
 ## Warnings and Risks
 - **Registry Edits**: Can cause system instability if misapplied—always create a restore point first.
-- **Backups**: Scripts back up keys automatically; check log if empty (normal if keys don't exist).
+- **Backups**: Scripts back up keys automatically; check the log if empty (normal if keys don't exist).
 - **Elevation**: Some tweaks require admin; scripts relaunch if needed.
 - **Reversal**: Use remove options to undo; test in VM if possible.
 - **Compatibility**: Win11 only; may break with updates—verify on your build.


### PR DESCRIPTION
## Summary
- clarify that users should "check the log" when backup keys are empty

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ce04244bc83278d1f7921167ed314